### PR TITLE
Switch to https location of schemastore

### DIFF
--- a/json-extension/src/browser/json-client-contribution.ts
+++ b/json-extension/src/browser/json-client-contribution.ts
@@ -46,7 +46,8 @@ export class JsonClientContribution extends BaseLanguageClientContribution {
     
     protected async initializeJsonSchemaAssociations() {
         const client = await this.languageClient;
-        const response = await fetch('http://schemastore.org/api/json/catalog.json');
+        const url = `${window.location.protocol}//schemastore.azurewebsites.net/api/json/catalog.json`;
+        const response = await fetch(url);
         const schemas: SchemaData[] = (await response.json()).schemas!;
         const registry: {[pattern: string]: string[]} = {};
         for (const s of schemas) {


### PR DESCRIPTION
http or https url of the schemastore should be used based on the current location.

Closes #4